### PR TITLE
pysmi 1.5.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pysmi" %}
-{% set version = "0.3.4" %}
-{% set sha256 = "bd15a15020aee8376cab5be264c26330824a8b8164ed0195bd402dd59e4e8f7c" %}
+{% set version = "1.5.9" %}
+{% set sha256 = "f6dfda838e3cba133169f1ff57f71a2841815d43db2e5c619b6e5db3b8560707" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,14 +43,14 @@ test:
     - pip check
 
 about:
-  home: https://pysmi.sourceforge.net/
+  home: https://www.pysnmp.com/pysmi/
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE.rst
   summary: SNMP SMI/MIB Parser
   description: 'A pure-Python implementation of SNMP/SMI MIB parsing and conversion library.'
-  doc_url: https://snmplabs.com/pysmi/#documentation
-  dev_url: https://github.com/etingof/pysmi
+  doc_url: https://docs.lextudio.com/pysmi/
+  dev_url: https://github.com/lextudio/pysmi
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,15 +37,19 @@ test:
     - pysmi.reader
     - pysmi.searcher
     - pysmi.writer
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http:/pysmi.sf.net
-  license: BSD 2-Clause
+  home: https://pysmi.sourceforge.net/
+  license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE.rst
   summary: SNMP SMI/MIB Parser
   description: 'A pure-Python implementation of SNMP/SMI MIB parsing and conversion library.'
-  doc_url: http://snmplabs.com/pysmi/#documentation
+  doc_url: https://snmplabs.com/pysmi/#documentation
   dev_url: https://github.com/etingof/pysmi
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,17 +13,19 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
 requirements:
   host:
     - python
+    - poetry-core >=1.0.0
     - setuptools
     - pip
   run:
     - python
-    - ply
+    - ply <4.0,>=3.11
+    - jinja2 <4.0.0,>=3.1.3
+    - requests <3.0.0,>=2.26.0
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6504](https://anaconda.atlassian.net/browse/PKG-6504)
- [Upstream repository](https://github.com/etingof/pysmi)
- Relevant dependency PRs:
  - `pysmi` 👉  `pysnmp'

### Explanation of changes:

- update version
- remove noarch
- update build script and dependencies
- add pip check
- other linter fixes

### Notes
- not sure what to do about the broken snmplabs.com link


[PKG-6504]: https://anaconda.atlassian.net/browse/PKG-6504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ